### PR TITLE
Context.UserEventType enums

### DIFF
--- a/lib/provider2.js
+++ b/lib/provider2.js
@@ -53,7 +53,11 @@ export default class Provider2 {
      return new Promise((resolve) => {
        var suggestions = []
 
-       if(previousWord == "Type" && prefix == '.') {
+       if(previousWord == "UserEventType" && prefix == '.') {
+         suggestions.push(...this.netsuiteData.userEventTypeEnum);
+       } else if(previousWord == "UserEventType" ) {
+         suggestions.push(...this.iterateNetSuiteData('userEventTypeEnum', prefix))
+       } else if(previousWord == "Type" && prefix == '.') {
          suggestions.push(...this.netsuiteData.recordTypeEnums);
        } else if(previousWord == "Type") {
          suggestions.push(...this.iterateNetSuiteData('recordTypeEnums', prefix))

--- a/netsuite-api2.json
+++ b/netsuite-api2.json
@@ -97,6 +97,145 @@
     "leftLabel": "void",
     "memberOf": "log"
   }],
+  "userEventTypeEnum": [{
+    "type": "constant",
+    "snippet": "APPROVE",
+    "leftLabel": "",
+    "description": "APPROVE event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "CANCEL",
+    "leftLabel": "",
+    "description": "CANCEL event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "CHANGEPASSWORD",
+    "leftLabel": "",
+    "description": "CHANGEPASSWORD event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "COPY",
+    "leftLabel": "",
+    "description": "COPY event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "CREATE",
+    "leftLabel": "",
+    "description": "CREATE event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "DELETE",
+    "leftLabel": "",
+    "description": "DELETE event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "DROPSHIP",
+    "leftLabel": "",
+    "description": "DROPSHIP event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "EDIT",
+    "leftLabel": "",
+    "description": "EDIT event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "EDITFORECAST",
+    "leftLabel": "",
+    "description": "EDITFORECAST event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "EMAIL",
+    "leftLabel": "",
+    "description": "EMAIL event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "MARKCOMPLETE",
+    "leftLabel": "",
+    "description": "MARKCOMPLETE event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "ORDERITEMS",
+    "leftLabel": "",
+    "description": "ORDERITEMS event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "PACK",
+    "leftLabel": "",
+    "description": "PACK event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "PAYBILLS",
+    "leftLabel": "",
+    "description": "PAYBILLS event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "PRINT",
+    "leftLabel": "",
+    "description": "PRINT event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "QUICKVIEW",
+    "leftLabel": "",
+    "description": "QUICKVIEW event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "RESASSIGN",
+    "leftLabel": "",
+    "description": "RESASSIGN event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "REJECT",
+    "leftLabel": "",
+    "description": "REJECT event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "SHIP",
+    "leftLabel": "",
+    "description": "SHIP event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "SPECIALORDER",
+    "leftLabel": "",
+    "description": "SPECIALORDER event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "TRANSFORM",
+    "leftLabel": "",
+    "description": "TRANSFORM event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "VIEW",
+    "leftLabel": "",
+    "description": "VIEW event type",
+    "memberOf": ""
+  }, {
+    "type": "constant",
+    "snippet": "XEDIT",
+    "leftLabel": "",
+    "description": "XEDIT event type",
+    "memberOf": ""
+  }],
   "recordTypeEnums": [{
     "type": "constant",
     "snippet": "ACCOUNT",


### PR DESCRIPTION
Added UserEventType "enums" that belong to the Context object, found here: [Help Centre: UserEventTypes](https://system.netsuite.com/app/help/helpcenter.nl?fid=section_4407992596.html)

Usage is fairly simple; 
```
//bad
if ( context.type === 'edit' )

//good
if( context.type === context.UserEventType.EDIT )
```

